### PR TITLE
clear ref added

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -74,6 +74,9 @@ const TextInputMask = forwardRef<Handles, TextInputMaskProps>(({
     },
     blur: () => {
       input.current?.blur()
+    },
+    clear: () => {
+      input.current?.clear()
     }
   }))
 
@@ -245,6 +248,7 @@ export interface TextInputMaskProps extends TextInputProps, MaskOptions{
 interface Handles {
   focus: () => void
   blur: () => void
+  clear: () => void
 }
 
 export default TextInputMask


### PR DESCRIPTION
I needed to use .clear() function but when I use ref.clear(), it says Cannot read property 'clear' of null. I realized component doesn't have clear function and I decided to add and send pr.